### PR TITLE
Add an error message explaining why the build failed

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -3,4 +3,7 @@
 
 set -eu -o pipefail
 
+echo "Builds are disabled on this app!" >&2
+echo "A common reason for this will be to enforce that deploys occur via another means (such as a pipeline promotion from staging)." >&2
+
 exit 1


### PR DESCRIPTION
Since if someone is unfamiliar with the "No!" buildpack, it's not currently clear why the build is failing for apps using it.

The error message has been kept fairly generic, since there are use-cases other than pipeline promotions where this buildpack is used (for example apps that use custom tooling to generate/upload slugs directly, eg [haikro](https://github.com/matthew-andrews/haikro)).