### PR TITLE
Add buildpacks:clear to usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ attempt.
 
 ## Usage
 
-Run the following command to overwrite existing buildpacks:
+Run the following commands to overwrite existing buildpacks:
 
+    $ heroku buildpacks:clear
     $ heroku buildpacks:set heroku-community/no


### PR DESCRIPTION
Since if the app had multiple buildpacks already, using `buildpacks:set` on its own will only overwrite the first buildpack, not the rest.

(As seen on a customer app recently, where the first buildpack was this buildpack, and the 2nd/3rd were real buildpacks.)